### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/authorization-service.yaml
+++ b/.github/workflows/authorization-service.yaml
@@ -55,7 +55,7 @@ jobs:
       run: echo "::set-output name=date::$(date +%s)"
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: rvalkenburg/kwetter-authorization-service
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/follow-service.yml
+++ b/.github/workflows/follow-service.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: rvalkenburg/kwetter-follow-service
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/kweet-service.yml
+++ b/.github/workflows/kweet-service.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: rvalkenburg/kwetter-kweet-service
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/ocelot-gateway.yaml
+++ b/.github/workflows/ocelot-gateway.yaml
@@ -47,7 +47,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: rvalkenburg/kwetter-ocelot-gateway
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/profile-service.yml
+++ b/.github/workflows/profile-service.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: rvalkenburg/kwetter-profile-service
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/search-service.yml
+++ b/.github/workflows/search-service.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: rvalkenburg/kwetter-search-service
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore